### PR TITLE
Remove initials from names

### DIFF
--- a/app/services/csv_reader.rb
+++ b/app/services/csv_reader.rb
@@ -11,7 +11,14 @@ class CsvReader
 
   def people
     CSV.read(in_path, headers: true).map do |row|
-      Person.new(row[1], row[2], row[0])
+      Person.new(strip_initials(row[1]), strip_initials(row[2]), row[0])
     end
+  end
+
+  private
+  def strip_initials(name)
+    name.split()
+      .select { |x| x.chomp('.').length > 1 }
+      .join(' ')
   end
 end

--- a/spec/fixtures/people.csv
+++ b/spec/fixtures/people.csv
@@ -1,3 +1,3 @@
 "email","given-names","family-name","active-nsf","rank"
-"eliotj@princeton.edu","Eliot","Jordan","n","sr"
-"windcowles@princeton.edu","Wind","Cowles","n","sr"
+"eliotj@princeton.edu","Eliot X.","Jordan","n","sr"
+"windcowles@princeton.edu","T Wind","Cowles","n","sr"


### PR DESCRIPTION
"What makes a middle name?" can get tricky. I decided on the rule "divide by whitespace, strip periods. Whatever's left in the array that is one letter, get rid of it". Better ideas are welcome. This does not discriminate between initials at the beginning or the end. It's applied to both the given and last name.

And I'm new to ruby, so styling suggestions to make this more idiomatic are welcome.